### PR TITLE
changes to ship/asteroid  behavior

### DIFF
--- a/scenes/Asteroid/Asteroid.tscn
+++ b/scenes/Asteroid/Asteroid.tscn
@@ -131,7 +131,8 @@ radius = 21.4507
 height = 20.1022
 
 [node name="Asteroid" type="RigidBody2D"]
-mode = 1
+collision_mask = 0
+gravity_scale = 0.0
 script = ExtResource( 2 )
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]

--- a/scenes/Player/Player.gd
+++ b/scenes/Player/Player.gd
@@ -1,8 +1,10 @@
 extends KinematicBody2D
 
+var hull_health = 100
 var acceleration: int = 250
 var max_speed: int = 500
 var rotation_speed: int = 150
+var inertia = 25
 var direction: Vector2
 var velocity: Vector2 = Vector2.ZERO
 onready var ship_nose: Node2D = $Sprite/Ship_Nose
@@ -34,8 +36,17 @@ func _physics_process(delta: float) -> void:
 	if Input.is_action_pressed("rotate_right"):
 		rotation_degrees+= rotation_speed * delta
 		
-	velocity = move_and_slide(velocity)
-	
+	velocity = move_and_slide(velocity, Vector2(0, 0), false, 4, 0.785, false)
+	for i in get_slide_count():
+		var collision = get_slide_collision(i)
+		print("Collided with ", collision.collider.name)
+		if collision.collider.name.begins_with("Asteroid"):
+			collision.collider.apply_central_impulse(-collision.normal * inertia)
+			if hull_health > 0:
+				hull_health = hull_health -10
+			else:
+				print("health is 0")
+				visible = false
 
 func _on_AnimatedSprite_animation_finished() -> void:
 	flame_exhaust.animation = "max-speed"


### PR DESCRIPTION
Changed a few things:
1. asteroids are now back to being rigid bodies but they still sit in place when you first load up.
2. ship now pushes asteroids when it collides with them, though the asteroids do lose velocity after a while instead of drifting infinitely through space.
3. ship has 100 health and loses 10hp upon contact with an asteroid. also you will get a log of things you hit when you go back to the godot editor at the bottom.
4. at 0 health the ship disappears visually. You can still fly around you just wont see it.