### PR TITLE
Autosave the game

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -92,8 +92,8 @@ config/icon="res://icon.png"
 
 [autoload]
 
-GameState="*res://state/GameState.gd"
 Constants="*res://lib/Constants.gd"
+GameState="*res://state/GameState.gd"
 
 [display]
 

--- a/scenes/Game/Game.gd
+++ b/scenes/Game/Game.gd
@@ -18,12 +18,12 @@ func _input(event) -> void:
 func _ready():
 	assert(GameState.connect("change_scene",self, "_change_scene") == 0)
 	assert(get_tree().get_root().connect("size_changed", self, "_size_changed_game") == 0)
-	GameState.scene = Constants.SceneId.StartMenu
+	GameState.load_from_save()
 	_size_changed_game()
 
 func _change_scene(sceneId):
-
 	if(root_scene_map.has(sceneId)):
+
 		var children_to_remove = $Content.get_children()
 		$Content.add_child(root_scene_map[sceneId].instance())
 		for n in children_to_remove:
@@ -45,6 +45,7 @@ func _on_Close_Menu_pressed():
 
 
 func _on_Quit_pressed():
+	GameState.save()
 	get_tree().quit()
 
 

--- a/scenes/Ships/Ship_controls.gd
+++ b/scenes/Ships/Ship_controls.gd
@@ -46,7 +46,7 @@ func _physics_process(delta: float) -> void:
 	
 	if GameState.player.hull_health <= 0: 
 		queue_free()
-	
+
 	GameState.player.position = self.position
 	
 	velocity = move_and_slide(velocity, Vector2(0, 0), false, 4, PI/4, false)

--- a/scenes/UI/UI.gd
+++ b/scenes/UI/UI.gd
@@ -9,6 +9,8 @@ extends CanvasLayer
 # Called when the node enters the scene tree for the first time.
 func _ready():
 	GameState.player.connect("hull_health_changed",self, "update_health")
+	update_health(GameState.player.hull_health)
+
 func update_health(val):
 	$ProgressBar.value = val
 

--- a/scenes/World/World.gd
+++ b/scenes/World/World.gd
@@ -1,8 +1,6 @@
 extends Node2D
 
 onready var pilot = $Pilot
-var player_ship = null
-var ship_name = null
 
 func _ready() -> void:
 	if GameState.player.character == null:
@@ -13,8 +11,7 @@ func _ready() -> void:
 		new_dialog.set_pause_mode(2)
 		get_tree().paused = true
 	else: 
-		pilot.add_child(GameState.player.ship.instance())
-		pilot.global_position = Vector2(640,520)
+		_spawn_ship()
 
 func _on_Dialog_timeline_end(_timeline_name) -> void:
 	get_tree().paused = false
@@ -22,18 +19,24 @@ func _on_Dialog_timeline_end(_timeline_name) -> void:
 
 func _on_Dialog_dialogic_signal(value) -> void:
 	if value == "Yam":
-		var harrier = load("res://scenes/Ships/Harrier/Harrier.tscn")
-		GameState.player.ship = harrier
-		player_ship = harrier.instance()
-		ship_name = "Harrier"
+		GameState.player.ship_type = "Harrier"
 	else:
-		var falcon = load("res://scenes/Ships/Falcon/Falcon.tscn")
-		GameState.player.ship = falcon
-		player_ship = falcon.instance()
-		ship_name = "Falcon"
+		GameState.player.ship_type = "Falcon"
 	
-	pilot.add_child(player_ship)
-	pilot.global_position = Vector2(640,520)
 	GameState.player.character = value
-	GameState.player.ship_type = ship_name
+	GameState.player.position = Vector2(-400, 0)
+	_spawn_ship()
+
+func _get_ship_class_from_name(ship_name):
+	if ship_name == "Harrier":
+		return load("res://scenes/Ships/Harrier/Harrier.tscn")
+	elif ship_name == "Falcon":
+		return load("res://scenes/Ships/Falcon/Falcon.tscn")
+	return null
 	
+func _spawn_ship():
+	var ship_class = _get_ship_class_from_name(GameState.player.ship_type)
+	if ship_class:
+		var ship_instance = ship_class.instance()
+		pilot.add_child(ship_instance)
+		ship_instance.position = GameState.player.position

--- a/state/GameState.gd
+++ b/state/GameState.gd
@@ -1,15 +1,47 @@
 extends Node
 
-var scene = null setget _set_scene
+var scene = Constants.SceneId.StartMenu setget _set_scene
 var player = PlayerState.new()
+var save_filename = "user://save_game.save"
 
 signal change_scene
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	pass
 
 func _set_scene(next_scene):
 	scene = next_scene
 	emit_signal("change_scene", next_scene) 
 	
+func toJSON():
+	return {
+		'scene': scene,
+		'player': player.toJSON()
+	}
+
+func save():
+	var save_file = File.new()
+	save_file.open(save_filename, File.WRITE)
+	save_file.store_line(to_json(toJSON()))
+	save_file.close()
+
+func load_from_save():
+	var save_file = File.new()
+	if not save_file.file_exists(save_filename):
+		return
+
+	save_file.open(save_filename,File.READ)
+	
+	var save_data = parse_json(save_file.get_as_text())
+	fromJSON(save_data)
+
+	save_file.close()
+
+func fromJSON(json):
+	player.fromJSON(json.player)
+	_set_scene(int(json.scene))
+
+func _notification(what: int) -> void:
+	if what == NOTIFICATION_WM_QUIT_REQUEST:
+		save()

--- a/state/PlayerState.gd
+++ b/state/PlayerState.gd
@@ -3,13 +3,27 @@ extends Node
 class_name PlayerState
 
 signal hull_health_changed
-var position = Vector2(50, 50)
-var hull_health = 100 setget set_hull_health
+var position = Vector2.ZERO
+var hull_health = 100 setget _set_hull_health
 var selection = null
 var character = null
 var ship_type = null
-var ship = null
 
-func set_hull_health(val):
+func _set_hull_health(val):
 	hull_health = val
 	emit_signal("hull_health_changed", hull_health) 
+
+func toJSON():
+	return {
+		'position_x': position.x,
+		'position_y': position.y,
+		'hull_health': hull_health,
+		'character': character,
+		'ship_type': ship_type
+	}
+
+func fromJSON(json):
+	position = Vector2(json.position_x, json.position_y)
+	_set_hull_health(json.hull_health)
+	character = json.character
+	ship_type = json.ship_type


### PR DESCRIPTION
I got annoyed having to click through the tutorial any time I wanted to test something so this PR adds saving to the game.

When the game is loaded it looks for a JSON file at `user://save_game.save`. If the file exists, it loads that JSON into the GameState. If it doesn't exist, then the game starts with the default GameState.

Any time you quit the game via the game menu or by ctrl+q it saves the current game state to `user://save_game.save`.

I also did some minor refactor work.

This PR uses the work that @j-rodriguez99 did in #31 so I cut my branch from `tutorial_fix` rather than main.