### PR TITLE
button on surface scene to leave now

### DIFF
--- a/art/Planet surface backgrounds/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png.import
+++ b/art/Planet surface backgrounds/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png.import
@@ -1,0 +1,35 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png-867a285ff5d26ccd7eedc9917964ce50.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://art/Planet surface backgrounds/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png"
+dest_files=[ "res://.import/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png-867a285ff5d26ccd7eedc9917964ce50.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/scenes/Game/Game.tscn
+++ b/scenes/Game/Game.tscn
@@ -15,6 +15,7 @@ anchor_bottom = 1.0
 
 [node name="MainMenu" type="CanvasLayer" parent="."]
 layer = 100
+visible = false
 
 [node name="MainMenuPanel" type="Panel" parent="MainMenu"]
 anchor_left = 0.5

--- a/scenes/Game/Game.tscn
+++ b/scenes/Game/Game.tscn
@@ -15,7 +15,6 @@ anchor_bottom = 1.0
 
 [node name="MainMenu" type="CanvasLayer" parent="."]
 layer = 100
-visible = false
 
 [node name="MainMenuPanel" type="Panel" parent="MainMenu"]
 anchor_left = 0.5

--- a/scenes/PlanetSurface/PlanetSurface.gd
+++ b/scenes/PlanetSurface/PlanetSurface.gd
@@ -1,4 +1,4 @@
-extends CanvasLayer
+extends Control
 
 
 # Declare member variables here. Examples:
@@ -10,9 +10,6 @@ extends CanvasLayer
 func _ready():
 	pass # Replace with function body.
 
-func _input(event) -> void:
-	if event.is_action_pressed("take_off"):
-		GameState.scene = Constants.SceneId.World
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta):
-#	pass
+
+func _on_Leave_pressed():
+	GameState.scene = Constants.SceneId.World

--- a/scenes/PlanetSurface/PlanetSurface.tscn
+++ b/scenes/PlanetSurface/PlanetSurface.tscn
@@ -9,14 +9,9 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 script = ExtResource( 1 )
 
-[node name="Background" type="CanvasLayer" parent="."]
-layer = 0
-
-[node name="TextureRect" type="TextureRect" parent="Background"]
+[node name="TextureRect" type="TextureRect" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
-margin_top = -1300.0
-margin_bottom = 20.0
 texture = ExtResource( 2 )
 expand = true
 stretch_mode = 3

--- a/scenes/PlanetSurface/PlanetSurface.tscn
+++ b/scenes/PlanetSurface/PlanetSurface.tscn
@@ -1,8 +1,13 @@
-[gd_scene load_steps=4 format=2]
+[gd_scene load_steps=6 format=2]
 
 [ext_resource path="res://scenes/PlanetSurface/PlanetSurface.gd" type="Script" id=1]
 [ext_resource path="res://scenes/PlanetSurface/art/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png" type="Texture" id=2]
 [ext_resource path="res://themes/start_menu.tres" type="Theme" id=3]
+[ext_resource path="res://themes/fonts/SpaceGrotesk-SemiBold.ttf" type="DynamicFontData" id=4]
+
+[sub_resource type="DynamicFont" id=1]
+size = 25
+font_data = ExtResource( 4 )
 
 [node name="Control" type="Control"]
 anchor_right = 1.0
@@ -12,19 +17,26 @@ script = ExtResource( 1 )
 [node name="TextureRect" type="TextureRect" parent="."]
 anchor_right = 1.0
 anchor_bottom = 1.0
+margin_top = -1329.0
+margin_bottom = 34.0
+rect_pivot_offset = Vector2( 960, 1750 )
+size_flags_horizontal = 3
+size_flags_vertical = 3
 texture = ExtResource( 2 )
 expand = true
-stretch_mode = 3
+stretch_mode = 7
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
 [node name="PlanetPanel" type="Panel" parent="CanvasLayer"]
-anchor_right = 1.0
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
 anchor_bottom = 1.0
-margin_left = 100.0
-margin_top = 650.0
-margin_right = -100.0
-margin_bottom = -50.0
+margin_left = -860.0
+margin_top = -444.0
+margin_right = 860.0
+margin_bottom = -64.0
 theme = ExtResource( 3 )
 
 [node name="surfacelocations" type="VBoxContainer" parent="CanvasLayer/PlanetPanel"]
@@ -33,45 +45,66 @@ margin_top = 50.0
 margin_right = 500.0
 margin_bottom = 330.0
 theme = ExtResource( 3 )
+custom_constants/separation = 20
 
 [node name="Bar" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations"]
 margin_right = 450.0
-margin_bottom = 41.0
+margin_bottom = 80.0
+rect_min_size = Vector2( 0, 80 )
 text = "Bar"
 
 [node name="Missions" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations"]
-margin_top = 45.0
+margin_top = 100.0
 margin_right = 450.0
-margin_bottom = 86.0
+margin_bottom = 180.0
+grow_vertical = 2
+rect_min_size = Vector2( 0, 80 )
 text = "Missions"
 
 [node name="Trade Center" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations"]
-margin_top = 90.0
+margin_top = 200.0
 margin_right = 450.0
-margin_bottom = 131.0
+margin_bottom = 280.0
+rect_min_size = Vector2( 0, 80 )
 text = "Trade Center"
+
+[node name="RichTextLabel" type="RichTextLabel" parent="CanvasLayer/PlanetPanel"]
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+margin_left = -287.5
+margin_top = -130.5
+margin_right = 287.5
+margin_bottom = 130.5
+custom_fonts/normal_font = SubResource( 1 )
+text = "This is the planet surface, Welcome!"
 
 [node name="surfacelocations2" type="VBoxContainer" parent="CanvasLayer/PlanetPanel"]
 margin_left = 1220.0
 margin_top = 50.0
 margin_right = 1670.0
 margin_bottom = 330.0
+custom_constants/separation = 20
 
 [node name="Outfitter" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations2"]
 margin_right = 450.0
-margin_bottom = 41.0
+margin_bottom = 80.0
+rect_min_size = Vector2( 0, 80 )
 text = "Outfitter"
 
 [node name="Refuel" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations2"]
-margin_top = 45.0
+margin_top = 100.0
 margin_right = 450.0
-margin_bottom = 86.0
+margin_bottom = 180.0
+rect_min_size = Vector2( 0, 80 )
 text = "Refuel"
 
 [node name="Leave" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations2"]
-margin_top = 90.0
+margin_top = 200.0
 margin_right = 450.0
-margin_bottom = 131.0
+margin_bottom = 280.0
+rect_min_size = Vector2( 0, 80 )
 text = "Leave"
 
 [connection signal="pressed" from="CanvasLayer/PlanetPanel/surfacelocations2/Leave" to="." method="_on_Leave_pressed"]

--- a/scenes/PlanetSurface/PlanetSurface.tscn
+++ b/scenes/PlanetSurface/PlanetSurface.tscn
@@ -1,12 +1,82 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://scenes/PlanetSurface/PlanetSurface.gd" type="Script" id=1]
+[ext_resource path="res://scenes/PlanetSurface/art/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png" type="Texture" id=2]
+[ext_resource path="res://themes/start_menu.tres" type="Theme" id=3]
 
-[node name="CanvasLayer" type="CanvasLayer"]
+[node name="Control" type="Control"]
+anchor_right = 1.0
+anchor_bottom = 1.0
 script = ExtResource( 1 )
 
-[node name="TextureRect" type="TextureRect" parent="."]
-margin_right = 1920.0
-margin_bottom = 1080.0
+[node name="Background" type="CanvasLayer" parent="."]
+layer = 0
+
+[node name="TextureRect" type="TextureRect" parent="Background"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_top = -1300.0
+margin_bottom = 20.0
+texture = ExtResource( 2 )
 expand = true
-stretch_mode = 6
+stretch_mode = 3
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="PlanetPanel" type="Panel" parent="CanvasLayer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = 100.0
+margin_top = 650.0
+margin_right = -100.0
+margin_bottom = -50.0
+theme = ExtResource( 3 )
+
+[node name="surfacelocations" type="VBoxContainer" parent="CanvasLayer/PlanetPanel"]
+margin_left = 50.0
+margin_top = 50.0
+margin_right = 500.0
+margin_bottom = 330.0
+theme = ExtResource( 3 )
+
+[node name="Bar" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations"]
+margin_right = 450.0
+margin_bottom = 41.0
+text = "Bar"
+
+[node name="Missions" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations"]
+margin_top = 45.0
+margin_right = 450.0
+margin_bottom = 86.0
+text = "Missions"
+
+[node name="Trade Center" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations"]
+margin_top = 90.0
+margin_right = 450.0
+margin_bottom = 131.0
+text = "Trade Center"
+
+[node name="surfacelocations2" type="VBoxContainer" parent="CanvasLayer/PlanetPanel"]
+margin_left = 1220.0
+margin_top = 50.0
+margin_right = 1670.0
+margin_bottom = 330.0
+
+[node name="Outfitter" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations2"]
+margin_right = 450.0
+margin_bottom = 41.0
+text = "Outfitter"
+
+[node name="Refuel" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations2"]
+margin_top = 45.0
+margin_right = 450.0
+margin_bottom = 86.0
+text = "Refuel"
+
+[node name="Leave" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations2"]
+margin_top = 90.0
+margin_right = 450.0
+margin_bottom = 131.0
+text = "Leave"
+
+[connection signal="pressed" from="CanvasLayer/PlanetPanel/surfacelocations2/Leave" to="." method="_on_Leave_pressed"]

--- a/scenes/PlanetSurface/art/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png.import
+++ b/scenes/PlanetSurface/art/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png.import
@@ -1,0 +1,35 @@
+[remap]
+
+importer="texture"
+type="StreamTexture"
+path="res://.import/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png-0f002756fab13a181f1600eb2ac6e73d.stex"
+metadata={
+"vram_texture": false
+}
+
+[deps]
+
+source_file="res://scenes/PlanetSurface/art/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png"
+dest_files=[ "res://.import/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png-0f002756fab13a181f1600eb2ac6e73d.stex" ]
+
+[params]
+
+compress/mode=0
+compress/lossy_quality=0.7
+compress/hdr_mode=0
+compress/bptc_ldr=0
+compress/normal_map=0
+flags/repeat=0
+flags/filter=true
+flags/mipmaps=false
+flags/anisotropic=false
+flags/srgb=2
+process/fix_alpha_border=true
+process/premult_alpha=false
+process/HDR_as_SRGB=false
+process/invert_color=false
+process/normal_map_invert_y=false
+stream=false
+size_limit=0
+detect_3d=true
+svg/scale=1.0

--- a/scenes/PlanetSurface/art/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png:Zone.Identifier
+++ b/scenes/PlanetSurface/art/rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png:Zone.Identifier
@@ -1,0 +1,4 @@
+[ZoneTransfer]
+ZoneId=3
+ReferrerUrl=https://picresize.com/en/results
+HostUrl=https://picresize.com/dl.php?i=rsz_18x_-_sci_fi_hangar_with_mechanics_and_space_ships.png

--- a/scenes/Ships/Ship_controls.gd
+++ b/scenes/Ships/Ship_controls.gd
@@ -101,8 +101,8 @@ func handle_landing_request():
 			print ("Landing sequence initiated")
 			GameState.scene = Constants.SceneId.PlanetSurface
 
-func _input(select_planet):
-	if Input.is_action_pressed("select_planet"):
+func _input(event):
+	if event.is_action_pressed("select_planet"):
 		handle_landing_request()
 
 


### PR DESCRIPTION
changed some stuff in the planet scene
- changed the main node to a control node so we can manage the buttons to switch to different backgrounds potentially
- added a background that you see when you switch to it, thinking about making this background the one for refueling
- there are buttons now! the only one that works is the leave button which takes over what we used to press esc for. esc should now only open the game menu.

i also added the image i used for the backround to the general art folder under a planet surface backgrounds folder i added