### PR TITLE
Add a jump command that allows you to jump from one system to another

### DIFF
--- a/lib/state/PlayerState.gd
+++ b/lib/state/PlayerState.gd
@@ -3,18 +3,24 @@ extends Node
 class_name PlayerState
 
 signal hull_health_changed
+signal system_id_changed
 var position = Vector2.ZERO
 var hull_health = 100 setget _set_hull_health
 var selection = null
 var character = null
 var ship_type = null
 var system_id = 1
-var planet_id = null
+var system_id = 1 setget _set_system_id
 var nav_route = []
 
 func _set_hull_health(val):
 	hull_health = val
-	emit_signal("hull_health_changed", hull_health) 
+	emit_signal("hull_health_changed", hull_health)
+
+func _set_system_id(val):
+	var previous_system_id = system_id
+	system_id = val
+	emit_signal("system_id_changed", system_id, previous_system_id)
 
 func toJSON():
 	return {

--- a/project.godot
+++ b/project.godot
@@ -194,6 +194,11 @@ nav_multi={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":16777237,"unicode":0,"echo":false,"script":null)
  ]
 }
+jump={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":74,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 
 [physics]
 

--- a/scenes/Ships/Ship_controls.gd
+++ b/scenes/Ships/Ship_controls.gd
@@ -101,9 +101,19 @@ func handle_landing_request():
 			print ("Landing sequence initiated")
 			GameState.scene = Constants.SceneId.PlanetSurface
 
+func handle_jump_request():
+	print('Jump request')
+	if(GameState.player.nav_route.size() == 0):
+		print('Open the map to set where you would like to jump')
+	else:
+		GameState.player.system_id = GameState.player.nav_route.pop_front()
+		print("Jumped to ", GameState.player.system_id, " nav_route = ", GameState.player.nav_route)
+
 func _input(event):
 	if event.is_action_pressed("select_planet"):
 		handle_landing_request()
+	if event.is_action_pressed("jump"):
+		handle_jump_request()
 
 
 	

--- a/scenes/UI/SystemMap/SystemMap.gd
+++ b/scenes/UI/SystemMap/SystemMap.gd
@@ -106,7 +106,7 @@ func _system_id_changed(_current_system_id, _previous_system_id):
 
 func _render_systems():
 	for child in system_container.get_children():
-		remove_child(child)
+		system_container.remove_child(child)
 		child.queue_free()
 	_system_nodes = {}
 	_system_edges = {}


### PR DESCRIPTION
This PR starts the initial work for hyper jump functionality.

* Add new key binding `j` for hyper jump
* When `j` is pressed, it checks to see if there are any systems in the players current nav_route.
  * If not, it prints a message informing the player to use the map to select where they want to go
  * If so, it changes the player state `system_id` to reflect the next value in the nav_route and removes that value from the nav route as well as emits a new `system_id_changed` signal.
* The map listens for the `system_id_changed` signal and updates it's UI to reflect the new system and updated nav route.

To Test:

* Open the map and select your route
* Press `j`
* Map should show that you have moved to the next system in the nav route and update