### PR TITLE
Update controls

### DIFF
--- a/project.godot
+++ b/project.godot
@@ -124,7 +124,7 @@ ui_accept={
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777222,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
 , Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
-, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":82,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":70,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
  ]
 }
 rotate_left={

--- a/project.godot
+++ b/project.godot
@@ -142,6 +142,7 @@ flip_maneuver={
 select_planet={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":76,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":88,"unicode":0,"echo":false,"script":null)
  ]
 }
 dialogic_default_action={
@@ -155,12 +156,14 @@ dialogic_default_action={
 }
 take_off={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":84,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":88,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":76,"unicode":0,"echo":false,"script":null)
  ]
 }
 toggle_system_map={
 "deadzone": 0.5,
-"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":77,"unicode":0,"echo":false,"script":null)
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":67,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":77,"unicode":0,"echo":false,"script":null)
  ]
 }
 system_map_cam_drag={

--- a/project.godot
+++ b/project.godot
@@ -119,6 +119,14 @@ common/drop_mouse_on_gui_input_disabled=true
 
 [input]
 
+ui_accept={
+"deadzone": 0.5,
+"events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777221,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":16777222,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+, Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":0,"button_index":0,"pressure":0.0,"pressed":false,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":82,"physical_scancode":0,"unicode":0,"echo":false,"script":null)
+ ]
+}
 rotate_left={
 "deadzone": 0.5,
 "events": [ Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false,"shift":false,"control":false,"meta":false,"command":false,"pressed":false,"scancode":0,"physical_scancode":65,"unicode":0,"echo":false,"script":null)

--- a/scenes/Game/Game.gd
+++ b/scenes/Game/Game.gd
@@ -1,6 +1,7 @@
 extends Control
 
 var systems = null
+onready var Menu = $MainMenu/MainMenuPanel/ButtonContainer/NewGame
 
 var root_scene_map = {
 	Constants.SceneId.StartMenu: preload("res://scenes/StartMenu/StartMenu.tscn"),
@@ -15,6 +16,7 @@ func _input(event) -> void:
 		)
 		
 		$MainMenu.visible = !$MainMenu.visible
+		Menu.grab_focus()
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/scenes/Game/Game.gd
+++ b/scenes/Game/Game.gd
@@ -17,6 +17,12 @@ func _input(event) -> void:
 		
 		$MainMenu.visible = !$MainMenu.visible
 		Menu.grab_focus()
+	if event.is_action_pressed("ui_select"):
+		if $MainMenu/MainMenuPanel/ButtonContainer/NewGame.has_focus():
+			$MainMenu/MainMenuPanel/ButtonContainer/NewGame.release_focus()
+		else:
+			$MainMenu/MainMenuPanel/ButtonContainer/NewGame.grab_focus()
+	
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/scenes/Game/Game.gd
+++ b/scenes/Game/Game.gd
@@ -17,12 +17,6 @@ func _input(event) -> void:
 		
 		$MainMenu.visible = !$MainMenu.visible
 		Menu.grab_focus()
-	if event.is_action_pressed("ui_select"):
-		if $MainMenu/MainMenuPanel/ButtonContainer/NewGame.has_focus():
-			$MainMenu/MainMenuPanel/ButtonContainer/NewGame.release_focus()
-		else:
-			$MainMenu/MainMenuPanel/ButtonContainer/NewGame.grab_focus()
-	
 
 # Called when the node enters the scene tree for the first time.
 func _ready():

--- a/scenes/Game/Game.tscn
+++ b/scenes/Game/Game.tscn
@@ -44,6 +44,10 @@ margin_bottom = 88.0
 margin_right = 241.0
 margin_bottom = 41.0
 rect_pivot_offset = Vector2( 263, 47.5 )
+focus_neighbour_top = NodePath("../Quit")
+focus_neighbour_bottom = NodePath("../NewGame")
+focus_next = NodePath("../NewGame")
+focus_previous = NodePath("../Quit")
 text = "Close Menu"
 
 [node name="NewGame" type="Button" parent="MainMenu/MainMenuPanel/ButtonContainer"]
@@ -51,6 +55,10 @@ margin_top = 45.0
 margin_right = 241.0
 margin_bottom = 86.0
 rect_pivot_offset = Vector2( 263, 47.5 )
+focus_neighbour_top = NodePath("../Close Menu")
+focus_neighbour_bottom = NodePath("../FullScreen")
+focus_next = NodePath("../FullScreen")
+focus_previous = NodePath("../Close Menu")
 text = "New Game"
 
 [node name="FullScreen" type="Button" parent="MainMenu/MainMenuPanel/ButtonContainer"]
@@ -58,6 +66,10 @@ margin_top = 90.0
 margin_right = 241.0
 margin_bottom = 131.0
 rect_pivot_offset = Vector2( 263, 47.5 )
+focus_neighbour_top = NodePath("../NewGame")
+focus_neighbour_bottom = NodePath("../Quit")
+focus_next = NodePath("../Quit")
+focus_previous = NodePath("../NewGame")
 text = "Exit Full Screen"
 
 [node name="Quit" type="Button" parent="MainMenu/MainMenuPanel/ButtonContainer"]
@@ -65,6 +77,10 @@ margin_top = 135.0
 margin_right = 241.0
 margin_bottom = 176.0
 rect_pivot_offset = Vector2( 263, 47.5 )
+focus_neighbour_top = NodePath("../FullScreen")
+focus_neighbour_bottom = NodePath("../Close Menu")
+focus_next = NodePath("../Close Menu")
+focus_previous = NodePath("../FullScreen")
 text = "Quit Game"
 
 [connection signal="pressed" from="MainMenu/MainMenuPanel/ButtonContainer/Close Menu" to="." method="_on_Close_Menu_pressed"]

--- a/scenes/PlanetSurface/PlanetSurface.gd
+++ b/scenes/PlanetSurface/PlanetSurface.gd
@@ -1,15 +1,21 @@
 extends Control
 
+onready var Surface_start = $CanvasLayer/PlanetPanel/surfacelocations/Bar
 
-# Declare member variables here. Examples:
-# var a = 2
-# var b = "text"
+func _ready() -> void:
+	Surface_start.grab_focus()
 
-
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass # Replace with function body.
+func _physics_process(delta):
+	if Input.is_action_just_pressed("ui_select"):
+		if $CanvasLayer/PlanetPanel/surfacelocations/Bar.has_focus():
+			$CanvasLayer/PlanetPanel/surfacelocations/Bar.release_focus()
+		else:
+			$CanvasLayer/PlanetPanel/surfacelocations/Bar.grab_focus()
 
 
 func _on_Leave_pressed():
 	GameState.scene = Constants.SceneId.World
+
+func _input(event):
+	if event.is_action_pressed("take_off"):
+		GameState.scene = Constants.SceneId.World

--- a/scenes/PlanetSurface/PlanetSurface.gd
+++ b/scenes/PlanetSurface/PlanetSurface.gd
@@ -5,17 +5,14 @@ onready var Surface_start = $CanvasLayer/PlanetPanel/surfacelocations/Bar
 func _ready() -> void:
 	Surface_start.grab_focus()
 
-func _physics_process(delta):
-	if Input.is_action_just_pressed("ui_select"):
-		if $CanvasLayer/PlanetPanel/surfacelocations/Bar.has_focus():
-			$CanvasLayer/PlanetPanel/surfacelocations/Bar.release_focus()
-		else:
-			$CanvasLayer/PlanetPanel/surfacelocations/Bar.grab_focus()
-
-
 func _on_Leave_pressed():
 	GameState.scene = Constants.SceneId.World
 
 func _input(event):
+	if event.is_action_just_pressed("ui_select"):
+		if $CanvasLayer/PlanetPanel/surfacelocations/Bar.has_focus():
+			$CanvasLayer/PlanetPanel/surfacelocations/Bar.release_focus()
+		else:
+			$CanvasLayer/PlanetPanel/surfacelocations/Bar.grab_focus()
 	if event.is_action_pressed("take_off"):
 		GameState.scene = Constants.SceneId.World

--- a/scenes/PlanetSurface/PlanetSurface.gd
+++ b/scenes/PlanetSurface/PlanetSurface.gd
@@ -9,7 +9,7 @@ func _on_Leave_pressed():
 	GameState.scene = Constants.SceneId.World
 
 func _input(event):
-	if event.is_action_just_pressed("ui_select"):
+	if event.is_action_pressed("ui_select"):
 		if $CanvasLayer/PlanetPanel/surfacelocations/Bar.has_focus():
 			$CanvasLayer/PlanetPanel/surfacelocations/Bar.release_focus()
 		else:

--- a/scenes/PlanetSurface/PlanetSurface.tscn
+++ b/scenes/PlanetSurface/PlanetSurface.tscn
@@ -51,6 +51,11 @@ custom_constants/separation = 20
 margin_right = 450.0
 margin_bottom = 80.0
 rect_min_size = Vector2( 0, 80 )
+focus_neighbour_top = NodePath("../../surfacelocations2/Leave")
+focus_neighbour_right = NodePath("../../surfacelocations2/Outfitter")
+focus_neighbour_bottom = NodePath("../Missions")
+focus_next = NodePath("../Missions")
+focus_previous = NodePath("../../surfacelocations2/Leave")
 text = "Bar"
 
 [node name="Missions" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations"]
@@ -59,6 +64,11 @@ margin_right = 450.0
 margin_bottom = 180.0
 grow_vertical = 2
 rect_min_size = Vector2( 0, 80 )
+focus_neighbour_top = NodePath("../Bar")
+focus_neighbour_right = NodePath("../../surfacelocations2/Refuel")
+focus_neighbour_bottom = NodePath("../Trade Center")
+focus_next = NodePath("../Trade Center")
+focus_previous = NodePath("../Bar")
 text = "Missions"
 
 [node name="Trade Center" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations"]
@@ -66,6 +76,11 @@ margin_top = 200.0
 margin_right = 450.0
 margin_bottom = 280.0
 rect_min_size = Vector2( 0, 80 )
+focus_neighbour_top = NodePath("../Missions")
+focus_neighbour_right = NodePath("../../surfacelocations2/Leave")
+focus_neighbour_bottom = NodePath("../../surfacelocations2/Outfitter")
+focus_next = NodePath("../../surfacelocations2/Outfitter")
+focus_previous = NodePath("../Missions")
 text = "Trade Center"
 
 [node name="RichTextLabel" type="RichTextLabel" parent="CanvasLayer/PlanetPanel"]
@@ -91,6 +106,11 @@ custom_constants/separation = 20
 margin_right = 450.0
 margin_bottom = 80.0
 rect_min_size = Vector2( 0, 80 )
+focus_neighbour_left = NodePath("../../surfacelocations/Bar")
+focus_neighbour_top = NodePath("../../surfacelocations/Trade Center")
+focus_neighbour_bottom = NodePath("../Refuel")
+focus_next = NodePath("../Refuel")
+focus_previous = NodePath("../../surfacelocations/Trade Center")
 text = "Outfitter"
 
 [node name="Refuel" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations2"]
@@ -98,6 +118,11 @@ margin_top = 100.0
 margin_right = 450.0
 margin_bottom = 180.0
 rect_min_size = Vector2( 0, 80 )
+focus_neighbour_left = NodePath("../../surfacelocations/Missions")
+focus_neighbour_top = NodePath("../Outfitter")
+focus_neighbour_bottom = NodePath("../Leave")
+focus_next = NodePath("../Leave")
+focus_previous = NodePath("../Outfitter")
 text = "Refuel"
 
 [node name="Leave" type="Button" parent="CanvasLayer/PlanetPanel/surfacelocations2"]
@@ -105,6 +130,11 @@ margin_top = 200.0
 margin_right = 450.0
 margin_bottom = 280.0
 rect_min_size = Vector2( 0, 80 )
+focus_neighbour_left = NodePath("../../surfacelocations/Trade Center")
+focus_neighbour_top = NodePath("../Refuel")
+focus_neighbour_bottom = NodePath("../../surfacelocations/Bar")
+focus_next = NodePath("../../surfacelocations/Bar")
+focus_previous = NodePath("../Refuel")
 text = "Leave"
 
 [connection signal="pressed" from="CanvasLayer/PlanetPanel/surfacelocations2/Leave" to="." method="_on_Leave_pressed"]

--- a/scenes/StartMenu/StartMenu.gd
+++ b/scenes/StartMenu/StartMenu.gd
@@ -6,12 +6,12 @@ onready var start_game = $VBoxContainer/Start
 func _ready() -> void:
 	start_game.grab_focus()
 	
-
-
-# Called every frame. 'delta' is the elapsed time since the previous frame.
-#func _process(delta: float) -> void:
-#	pass
-
+func _input(event):
+	if event.is_action_pressed("ui_select"):
+		if $VBoxContainer/Start.has_focus():
+			$VBoxContainer/Start.release_focus()
+		else:
+			$VBoxContainer/Start.grab_focus()
 
 func _on_Start_pressed() -> void:
 	GameState.player.queue_free()


### PR DESCRIPTION
Changed a couple of things for consistency and added more keybinds closer to wasd for better keyboard/mouse play.

- all the container menus can now scroll up/down with the arrow keys. Surface menu can also jump left to right but pressing left/right twice shouldnt jump you to the other side.(ie pressing right on leave wont bring you to trade center)
- removed spacebar from ui select so that spacebar toggles when you are in a container box or not, it shouldn't press any buttons. Before it would try to select the first selected box when you tried to refocus the container box.
- the esc menu box will automatically be selected when you open it. 

New keybinds for ship controls are as follows

- X can now be used to land on planets
- C can now open the system map
- F can be used to press the buttons on the ui menus  